### PR TITLE
feat: adds support for findN.

### DIFF
--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -231,14 +231,33 @@ func (r Replacer) ReplaceAll(haystack string, replaceWith []string) string {
 
 type Finder interface {
 	FindAll(haystack string) []Match
+	FindN(haystack string, n int) []Match
 	PatternCount() int
 }
 
 // FindAll returns the matches found in the haystack
 func (ac AhoCorasick) FindAll(haystack string) []Match {
-	iter := ac.Iter(haystack)
-	matches := make([]Match, 0)
+	return ac.FindN(haystack, -1)
+}
 
+// FindN returns the matches found in the haystack.
+//
+// The count determines the number of matches to return:
+//   n > 0: at most n matches
+//   n == 0: the result is nil (zero matches)
+//   n < 0: all matches
+func (ac AhoCorasick) FindN(haystack string, n int) []Match {
+	if n == 0 {
+		return nil
+	}
+
+	iter := ac.Iter(haystack)
+	var matches []Match
+	if n > 0 {
+		matches = make([]Match, 0, n)
+	}
+
+	i := 0
 	for {
 		next := iter.Next()
 		if next == nil {
@@ -246,6 +265,10 @@ func (ac AhoCorasick) FindAll(haystack string) []Match {
 		}
 
 		matches = append(matches, *next)
+		i++
+		if i == n {
+			break
+		}
 	}
 
 	return matches

--- a/ahocorasick_test.go
+++ b/ahocorasick_test.go
@@ -369,3 +369,16 @@ func BenchmarkAhoCorasick_LeftmostInsensitiveWholeWord(b *testing.B) {
 		}
 	}
 }
+
+func TestFindN(t *testing.T) {
+	builder := NewAhoCorasickBuilder(Opts{
+		AsciiCaseInsensitive: true,
+		MatchOnlyWholeWords:  true,
+		MatchKind:            LeftMostLongestMatch,
+	})
+	ac := builder.Build([]string{"bear", "Masha"})
+	matches := ac.FindN("The Bear and Masha", 1)
+	if want, have := 1, len(matches); want != have {
+		t.Errorf("unexpected number of matches, want: %d, have: %d", want, have)
+	}
+}


### PR DESCRIPTION
This PR adds support for `findN` function which would improve the user experience when the matching has a limit.

One example is [this snippet](https://github.com/corazawaf/coraza/blob/v3/dev/operators/pm_from_file.go#L55) where we match all but only want to deal with at most 10 matches.

No significant performance impact:

**Before**

```
goos: darwin
goarch: arm64
pkg: github.com/petar-dambovaliev/aho-corasick
BenchmarkAhoCorasick_LeftmostInsensitiveWholeWord-8   	   11784	     99401 ns/op	   71360 B/op	    1661 allocs/op
PASS
```
**After**

```
goos: darwin
goarch: arm64
pkg: github.com/petar-dambovaliev/aho-corasick
BenchmarkAhoCorasick_LeftmostInsensitiveWholeWord-8   	   11911	    101753 ns/op	   71360 B/op	    1661 allocs/op
PASS
```

Ping @anuraaga @jptosso