### PR TITLE
Fix leftMostLongestMatch returning all overlapping matches

### DIFF
--- a/ahocorasick.go
+++ b/ahocorasick.go
@@ -32,13 +32,19 @@ func (f *findIter) Next() *Match {
 		return nil
 	}
 
-	f.pos = result.end - result.len + 1
+	if result.end == f.pos {
+		f.pos += 1
+	} else {
+		f.pos = result.end
+	}
 
 	if f.matchOnlyWholeWords {
 		if result.Start()-1 >= 0 && (unicode.IsLetter(rune(f.haystack[result.Start()-1])) || unicode.IsDigit(rune(f.haystack[result.Start()-1]))) {
+			f.pos -= result.len - 1
 			return f.Next()
 		}
 		if result.end < len(f.haystack) && (unicode.IsLetter(rune(f.haystack[result.end])) || unicode.IsDigit(rune(f.haystack[result.end]))) {
+			f.pos -= result.len - 1
 			return f.Next()
 		}
 	}

--- a/ahocorasick_test.go
+++ b/ahocorasick_test.go
@@ -68,7 +68,25 @@ func TestOverlappingPatterns3(t *testing.T) {
 
 	trie := trieBuilder.Build(patterns)
 	result := trie.FindAll("test _test_1")
-	if len(result) != 2 {
+	if len(result) != 1 {
+		t.Logf("%v", result)
+		t.Error("Did not find match in string")
+		t.FailNow()
+	}
+}
+
+func TestOverlappingPatterns4(t *testing.T) {
+	trieBuilder := NewAhoCorasickBuilder(Opts{
+		MatchOnlyWholeWords: false,
+		MatchKind:           LeftMostFirstMatch,
+		DFA:                 false,
+	})
+
+	patterns := []string{"testing", "testing123"}
+
+	trie := trieBuilder.Build(patterns)
+	result := trie.FindAll("testing123")
+	if len(result) != 1 && result[0].end != 7 {
 		t.Logf("%v", result)
 		t.Error("Did not find match in string")
 		t.FailNow()


### PR DESCRIPTION
https://github.com/petar-dambovaliev/aho-corasick/pull/13 Caused overlapping patterns to return multiple matches.
This is fixed by only using the position new calculation for matches that are being cancelled due to MatchOnlyWholeWords.

Edit: Just realized that this only accounts for the cases where the begin position is different. (so, this is not a complete fix)
Example case where it will still fail:
```
func TestOverlappingPatterns4(t *testing.T) {
	trieBuilder := NewAhoCorasickBuilder(Opts{
		MatchOnlyWholeWords: true,
		MatchKind:           LeftMostLongestMatch,
		DFA:                 false,
	})

	patterns := []string{"testing", "testing 123"}

	trie := trieBuilder.Build(patterns)
	result := trie.FindAll("testing 12345")
	if len(result) != 1 {
		t.Logf("%v", result)
		t.Error("Did not find match in string")
		t.FailNow()
	}
}
```